### PR TITLE
Refactor AppData to use Lazy<T> for internal state

### DIFF
--- a/AppDataStorage.Test/AppDataTests.cs
+++ b/AppDataStorage.Test/AppDataTests.cs
@@ -233,7 +233,7 @@ public sealed class AppDataTests
 	[TestMethod]
 	public void TestLoadOrCreateHandlesCorruptFile()
 	{
-		var filePath = TestAppData.InternalState.FilePath;
+		var filePath = TestAppData.Get().FilePath;
 		AppData.EnsureDirectoryExists(filePath);
 		AppData.FileSystem.File.WriteAllText(filePath, "Invalid JSON");
 
@@ -444,7 +444,7 @@ public sealed class AppDataTests
 	[TestMethod]
 	public void TestLoadOrCreateRecoversFromCorruptBackup()
 	{
-		var filePath = TestAppData.InternalState.FilePath;
+		var filePath = TestAppData.Get().FilePath;
 		var backupFilePath = AppData.MakeBackupFilePath(filePath);
 
 		AppData.EnsureDirectoryExists(filePath);

--- a/AppDataStorage/AppData.cs
+++ b/AppDataStorage/AppData.cs
@@ -225,12 +225,12 @@ public abstract class AppData<T>() : IDisposable where T : AppData<T>, IDisposab
 	/// Gets the current instance of the app data.
 	/// </summary>
 	/// <returns>The current instance of the app data.</returns>
-	public static T Get() => InternalState;
+	public static T Get() => InternalState.Value;
 
 	/// <summary>
 	/// Gets the internal state of the app data.
 	/// </summary>
-	internal static T InternalState { get; } = LoadOrCreate(); // TODO: make this a Lazy<T>
+	internal static Lazy<T> InternalState { get; } = new(LoadOrCreate);
 
 	/// <summary>
 	/// Gets or sets the last save time of the app data.
@@ -398,11 +398,11 @@ public abstract class AppData<T>() : IDisposable where T : AppData<T>, IDisposab
 	/// <summary>
 	/// Queues a save operation for the current app data instance.
 	/// </summary>
-	public static void QueueSave() => InternalState.QueueSave();
+	public static void QueueSave() => Get().QueueSave();
 
 
 	/// <summary>
 	/// Saves the app data if required based on the debounce time and the last save time.
 	/// </summary>
-	public static void SaveIfRequired() => InternalState.SaveIfRequired();
+	public static void SaveIfRequired() => Get().SaveIfRequired();
 }


### PR DESCRIPTION
Refactor AppData<T> to use Lazy<T> for internal state initialization. Update methods in AppData.cs and AppDataTests.cs to accommodate this change. Modify `Get` method to return `InternalState.Value`. Adjust `QueueSave` and `SaveIfRequired` to call methods on the current instance of app data.