### PR TITLE
Don't serialise the lock member

### DIFF
--- a/AppDataStorage/AppData.cs
+++ b/AppDataStorage/AppData.cs
@@ -256,8 +256,10 @@ public abstract class AppData<T>() : IDisposable where T : AppData<T>, IDisposab
 	/// Gets the lock object used for synchronizing access to the app data instance.
 	/// </summary>
 #if NET8_0
+	[JsonIgnore]
 	public object Lock { get; } = new();
 #else
+	[JsonIgnore]
 	public Lock Lock { get; } = new();
 #endif
 


### PR DESCRIPTION
When viewing the serialised json file there is an extra member included in the output that is not required as it is the lock object.

Cut down example of my usage that contains the value
{
  "Lock": {
    "$id": "44",
    "IsHeldByCurrentThread": true
  }
}